### PR TITLE
Added action hooks to process_itn() function

### DIFF
--- a/wp-content/plugins/gravityformspayfast/class-gf-payfast.php
+++ b/wp-content/plugins/gravityformspayfast/class-gf-payfast.php
@@ -1284,6 +1284,9 @@ class GFPayFast extends GFPaymentAddOn
                     GFAPI::update_entry_property( $pfData['m_payment_id'], 'payment_status', 'Cancelled' );
                     GFFormsModel::add_note( $pfData['m_payment_id'], 0, 'PayFast', $note, 'Cancelled' );
 
+                    // Perform any custom actions
+                    do_action('gform_payfast_payment_cancelled', $pfData);
+
                     break;
 
                 case 'processed' :

--- a/wp-content/plugins/gravityformspayfast/class-gf-payfast.php
+++ b/wp-content/plugins/gravityformspayfast/class-gf-payfast.php
@@ -1272,6 +1272,9 @@ class GFPayFast extends GFPaymentAddOn
                         GFCommon::send_notifications( $notificationClientId, $form, $entry, true, 'form_submission' );
                     }
 
+                    // Perform any custom actions
+                    do_action('gform_payfast_payment_complete', $pfData);
+
                     break;
 
                 case 'CANCELLED':


### PR DESCRIPTION
These hooks allow developers to execute custom code in response to ITN messages without modifying the plugin.